### PR TITLE
【マークアップページ】ユーザー新規登録ログインページ

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -11,6 +11,7 @@
 @import "./devise/reg";
 @import "./devise/tell.scss";
 @import "./devise/add.scss";
+@import "./devise/pay.scss";
 @import "./mercari_top.scss";
 @import "./mercari_bottom.scss";
 @import "./devise/reg_header.scss";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -9,6 +9,7 @@
 @import "./circle";
 @import "./top";
 @import "./devise/reg";
+@import "./devise/tell.scss";
 @import "./mercari_top.scss";
 @import "./mercari_bottom.scss";
 @import "./devise/reg_header.scss";

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -10,6 +10,7 @@
 @import "./top";
 @import "./devise/reg";
 @import "./devise/tell.scss";
+@import "./devise/add.scss";
 @import "./mercari_top.scss";
 @import "./mercari_bottom.scss";
 @import "./devise/reg_header.scss";

--- a/app/assets/stylesheets/devise/_reg.scss
+++ b/app/assets/stylesheets/devise/_reg.scss
@@ -82,7 +82,7 @@
             margin: 0 auto;
             line-height: 50px;
             border: none;
-            margin-top: 20px;
+            margin-top: 50px;
           }
         }
 
@@ -94,7 +94,26 @@
       background-color: #ea352d;
       padding: 2px 4px;
     }
+    &__finish{
+      text-align: center;
+      padding: 40px 0px;
+    }
+    &__btn{
+      width: 350px;
+      height: 50px;
+      background-color:#ea352d;
+      color: white;
+      text-decoration: none;
+      display: block;
+      margin: 0 auto;
+      line-height: 50px;
+      border: none;
+      margin-top: 20px;
+    }
   }
 
+  }
+  &__bottom{
+    height: 100px;
   }
 }

--- a/app/assets/stylesheets/devise/_reg.scss
+++ b/app/assets/stylesheets/devise/_reg.scss
@@ -24,6 +24,7 @@
             height: 50px;
             border-radius: 5px;
             border: solid 0.5px #888888;
+            margin-top: 5px;
           }
           .input__half{
             height: 50px;

--- a/app/assets/stylesheets/devise/add.scss
+++ b/app/assets/stylesheets/devise/add.scss
@@ -1,0 +1,25 @@
+.form-optional{
+  background-color: #888888;
+  color: #fff;
+  padding: 2px 4px;
+  font-size: 12px;
+  border-radius: 2px;
+  vertical-align: center;
+}
+.add__submit{
+  margin-top: 40px;
+  &__btn{
+    width: 350px;
+    height: 50px;
+    background-color:#ea352d;
+    color: white;
+    text-decoration: none;
+    display: block;
+    margin: 0 auto;
+    line-height: 50px;
+    border: none;
+    margin-top: 20px;
+  }
+}
+
+// ボタンだけのページなど作る検討ーーscssきれいにまとめたい

--- a/app/assets/stylesheets/devise/pay.scss
+++ b/app/assets/stylesheets/devise/pay.scss
@@ -1,11 +1,24 @@
+.signup__wrapper__registration__form__code{
+  font-size: 14px;
+  color: #0099E8;
+  text-align: end;
+  margin-top: 5px;
+}
+
+#user_birth_year{
+  width: 70px;
+  height: 50px;
+  margin-top: 5px;
+}
+
 #user_birth_month{
   width: 70px;
   height: 50px;
   margin-top: 5px;
 }
-.signup__wrapper__registration__form__code{
-  font-size: 14px;
-  color: #0099E8;
-  text-align: end;
+
+#user_birth_day{
+  width: 70px;
+  height: 50px;
   margin-top: 5px;
 }

--- a/app/assets/stylesheets/devise/pay.scss
+++ b/app/assets/stylesheets/devise/pay.scss
@@ -1,0 +1,11 @@
+#user_birth_month{
+  width: 70px;
+  height: 50px;
+  margin-top: 5px;
+}
+.signup__wrapper__registration__form__code{
+  font-size: 14px;
+  color: #0099E8;
+  text-align: end;
+  margin-top: 5px;
+}

--- a/app/assets/stylesheets/devise/tell.scss
+++ b/app/assets/stylesheets/devise/tell.scss
@@ -1,0 +1,57 @@
+.signup {
+  &__wrapper{
+    width: 700px;
+    background-color: #fff;
+    margin: 0 auto;
+    padding-bottom: 40px;
+    &__title{
+      font-size: 25px;
+      text-align: center;
+      padding: 15px;
+      border-bottom:solid 1px #f5f5ff ;
+    }
+    &__tell{
+      width: 350px;
+      margin: 0 auto;
+      &__form{
+        width: 350px;
+        margin: 0 auto;
+        padding-top: 30px;  
+        &__title{
+          font-size: 14px;
+        }
+        .input__default{
+          width: 350px;
+          height: 50px;
+          border-radius: 5px;
+          border: solid 0.5px #888888;
+        }
+        &__message{
+          font-size: 13px;
+          color: #666666;
+          margin: 10px 0px;
+        }
+        &__submit{
+          margin-top: 50px;
+        }
+        .submit__btn{
+          width: 350px;
+          height: 50px;
+          background-color:#ea352d;
+          color: white;
+          text-decoration: none;
+          display: block;
+          margin: 0 auto;
+          line-height: 50px;
+          border: none;
+          margin-top: 20px;
+        }
+      }
+      &__reason{
+        font-size: 14px;
+        color: #0099E8;
+        text-align: end;
+      }
+    }
+  }
+}

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -9,7 +9,7 @@ class SignupController < ApplicationController
   end
 
   def tell
-
+    @user = User.new
   end
 
   def add

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -17,7 +17,7 @@ class SignupController < ApplicationController
   end
 
   def pay
-
+    @user = User.new
   end
   
   def finish

--- a/app/controllers/signup_controller.rb
+++ b/app/controllers/signup_controller.rb
@@ -13,7 +13,7 @@ class SignupController < ApplicationController
   end
 
   def add
-
+    @user = User.new
   end
 
   def pay

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,9 +1,9 @@
-= render "layouts/mercari_top"
+= render "signup/mercari_top"
 .new
   .new__box
     .new__box__title 
       .new__box__title__comment アカウントをお持ちでない方はこちら
-      =link_to "新規会員登録", "/", class:"registration"
+      =link_to "新規会員登録", top_signup_index_path, class:"registration"
     .new__box__form
       .new__box__form__btn
         =link_to "/", class:"new__box__form__btn__facebook" do
@@ -28,7 +28,7 @@
 
       .forget__pass
       =link_to "パスワードをお忘れの方", "devise/shared/links", class:"forget__pass"
-= render "layouts/mercari_bottom"
+= render "signup/mercari_bottom"
 
 .rc-anchor-center-item.rc-anchor-checkbox-holder
 -# <span class="recaptcha-checkbox goog-inline-block recaptcha-checkbox-unchecked rc-anchor-checkbox" role="checkbox" aria-checked="false" id="recaptcha-anchor" tabindex="0" dir="ltr" aria-labelledby="recaptcha-anchor-label"><div class="recaptcha-checkbox-border" role="presentation"></div><div class="recaptcha-checkbox-borderAnimation" role="presentation"></div><div class="recaptcha-checkbox-spinner" role="presentation"></div><div class="recaptcha-checkbox-spinnerAnimation" role="presentation"></div><div class="recaptcha-checkbox-checkmark" role="presentation"></div></span></div>

--- a/app/views/layouts/_header.html.haml
+++ b/app/views/layouts/_header.html.haml
@@ -35,6 +35,6 @@
       -else 
         .header__box__lower__user
           .header__box__lower__user__registration
-            =link_to "新規会員登録", new_user_registration_path, class:"header__box__lower__user__registration__red"
+            =link_to "新規会員登録", top_signup_index_path, class:"header__box__lower__user__registration__red"
           .header__box__lower__user__rogin
             =link_to "ログイン", new_user_session_path, class:"header__box__lower__user__rogin__blue"

--- a/app/views/signup/add.html.haml
+++ b/app/views/signup/add.html.haml
@@ -1,0 +1,55 @@
+= render "reg_header"
+.sigup
+  .signup__wrapper
+    .signup__wrapper__head 住所入力
+    .signup__wrapper__registration
+      .signup__wrapper__registration__form
+      = form_for @user, url: pay_signup_index_path, method: :get, html: {class: 'first-main__box'} do |f|
+        .signup__wrapper__registration__form__box
+          お名前
+          %span.form-require 必須
+          .signup-content__input-location
+          = f.text_field :email, placeholder: '  例) 山田', class:"input__default"
+          .signup-content__input-location
+          = f.text_field :email, placeholder: '  例) 綾', class:"input__default"
+        .signup__wrapper__registration__form__box
+          お名前カナ
+          %span.form-require 必須
+          .signup-content__input-location
+          = f.text_field :email, placeholder: '  例)  ヤマダ', class:"input__default"
+          .signup-content__input-location
+          = f.text_field :email, placeholder: '  例) アヤ', class:"input__default"
+        .signup__wrapper__registration__form__box
+          郵便番号
+          %span.form-require 必須
+          .signup-content__input-location
+          = f.text_field :email, placeholder: '  例) 123-456', class:"input__default"
+        .signup__wrapper__registration__form__box
+          都道府県
+          %span.form-require 必須
+          .signup-content__input-location
+          = f.text_field :email, placeholder: '  例) 北海道', class:"input__default"
+        .signup__wrapper__registration__form__box
+          市区町村
+          %span.form-require 必須
+          .signup-content__input-location
+          = f.text_field :email, placeholder: '  例) 横浜市緑区', class:"input__default"
+        .signup__wrapper__registration__form__box
+          番地
+          %span.form-require 必須
+          .signup-content__input-location
+          = f.text_field :email, placeholder: '  例) 青山1−1−1', class:"input__default"
+        .signup__wrapper__registration__form__box
+          建物名
+          %span.form-optional 任意
+          .signup-content__input-location
+          = f.text_field :email, placeholder: '  例) 柳ビル103', class:"input__default"
+        .signup__wrapper__registration__form__box
+          電話
+          %span.form-optional 任意
+          .signup-content__input-location
+          = f.text_field :email, placeholder: '  例) 090-1234-5678', class:"input__default"
+        .add__submit
+        =f.submit "次へ進む", class:"add__submit__btn"
+= render "mercari_bottom"
+

--- a/app/views/signup/add.html.haml
+++ b/app/views/signup/add.html.haml
@@ -6,20 +6,6 @@
       .signup__wrapper__registration__form
       = form_for @user, url: pay_signup_index_path, method: :get, html: {class: 'first-main__box'} do |f|
         .signup__wrapper__registration__form__box
-          お名前
-          %span.form-require 必須
-          .signup-content__input-location
-          = f.text_field :email, placeholder: '  例) 山田', class:"input__default"
-          .signup-content__input-location
-          = f.text_field :email, placeholder: '  例) 綾', class:"input__default"
-        .signup__wrapper__registration__form__box
-          お名前カナ
-          %span.form-require 必須
-          .signup-content__input-location
-          = f.text_field :email, placeholder: '  例)  ヤマダ', class:"input__default"
-          .signup-content__input-location
-          = f.text_field :email, placeholder: '  例) アヤ', class:"input__default"
-        .signup__wrapper__registration__form__box
           郵便番号
           %span.form-require 必須
           .signup-content__input-location
@@ -28,28 +14,43 @@
           都道府県
           %span.form-require 必須
           .signup-content__input-location
-          = f.text_field :email, placeholder: '  例) 北海道', class:"input__default"
+          = f.text_field :prefecture, placeholder: '  例) 北海道', class:"input__default"
         .signup__wrapper__registration__form__box
           市区町村
           %span.form-require 必須
           .signup-content__input-location
-          = f.text_field :email, placeholder: '  例) 横浜市緑区', class:"input__default"
+          = f.text_field :municipalities, placeholder: '  例) 横浜市緑区', class:"input__default"
         .signup__wrapper__registration__form__box
           番地
           %span.form-require 必須
           .signup-content__input-location
-          = f.text_field :email, placeholder: '  例) 青山1−1−1', class:"input__default"
+          = f.text_field :address, placeholder: '  例) 青山1−1−1', class:"input__default"
         .signup__wrapper__registration__form__box
           建物名
           %span.form-optional 任意
           .signup-content__input-location
-          = f.text_field :email, placeholder: '  例) 柳ビル103', class:"input__default"
+          = f.text_field :building, placeholder: '  例) 柳ビル103', class:"input__default"
         .signup__wrapper__registration__form__box
           電話
           %span.form-optional 任意
           .signup-content__input-location
-          = f.text_field :email, placeholder: '  例) 090-1234-5678', class:"input__default"
+          = f.text_field :phone_number, placeholder: '  例) 090-1234-5678', class:"input__default"
         .add__submit
         =f.submit "次へ進む", class:"add__submit__btn"
 = render "mercari_bottom"
 
+-# .signup__wrapper__registration__form__box
+-#           お名前
+-#           %span.form-require 必須
+-#           .signup-content__input-location
+-#           = f.text_field :f_name_kanji, placeholder: '  例) 山田', class:"input__default"
+-#           .signup-content__input-location
+-#           = f.text_field :l_name_kanji, placeholder: '  例) 綾', class:"input__default"
+  
+-#                .signup__wrapper__registration__form__box
+-#           お名前カナ
+-#           %span.form-require 必須
+-#           .signup-content__input-location
+-#           = f.text_field :f_name_kana, placeholder: '  例)  ヤマダ', class:"input__default"
+-#           .signup-content__input-location
+-#           = f.text_field :l_name_kana, placeholder: '  例) アヤ', class:"input__default"

--- a/app/views/signup/finish.html.haml
+++ b/app/views/signup/finish.html.haml
@@ -1,0 +1,12 @@
+= render "reg_header"
+.sigup
+  .signup__wrapper
+    .signup__wrapper__head 会員登録完了
+    .signup__wrapper__registration
+      .signup__wrapper__registration__finish
+        ありがとうございます。<br>
+        会員登録が完了しました。
+        =link_to "メルカリをはじめる", root_path, class:"signup__wrapper__registration__btn"
+          
+  .signup__bottom
+= render "layouts/footer"

--- a/app/views/signup/pay.html.haml
+++ b/app/views/signup/pay.html.haml
@@ -10,8 +10,6 @@
           %span.form-require 必須
           .signup-content__input-location
           = f.text_field :email, placeholder: '  例) 山田', class:"input__default"
-          .signup__wrapper__registration__form__box__logo
-            クレジット会社のマーク
         .signup__wrapper__registration__form__box
           有効期限
           %span.form-require 必須

--- a/app/views/signup/pay.html.haml
+++ b/app/views/signup/pay.html.haml
@@ -1,0 +1,33 @@
+= render "reg_header"
+.sigup
+  .signup__wrapper
+    .signup__wrapper__head 支払い方法
+    .signup__wrapper__registration
+      .signup__wrapper__registration__form
+      = form_for @user, url: finish_signup_index_path, method: :get, html: {class: 'first-main__box'} do |f|
+        .signup__wrapper__registration__form__box
+          カード番号
+          %span.form-require 必須
+          .signup-content__input-location
+          = f.text_field :email, placeholder: '  例) 山田', class:"input__default"
+          .signup__wrapper__registration__form__box__logo
+            クレジット会社のマーク
+        .signup__wrapper__registration__form__box
+          有効期限
+          %span.form-require 必須
+          .signup-content__input-location
+          = f.select :birth_month, [["01", "01"], ["02", "02"],["03", "03"],["04", "04"],["05", "05"],["06", "06"],["07", "07"],["08", "08"],["09", "09"],["10", "10"],["11", "11"],["12", "12"]], class:"input__number"
+          月
+          .signup-content__input-location
+          = f.select :birth_month, [["2019", "2019"], ["2020", "2020"],["2021", "2021"],["2023", "2023"],["2024", "2024"],["2025", "2025"],["2026", "2026"],["2027", "2027"],["2028", "2028"],["2029", "2029"]], class:"input__number"
+          年
+        .signup__wrapper__registration__form__box
+          セキュリティーコード
+          %span.form-require 必須
+          .signup-content__input-location
+          = f.text_field :email, placeholder: '  カード背面４桁もしくは３桁の番号', class:"input__default"
+          .signup__wrapper__registration__form__code
+            %i.fas.fa-question-circle カード裏面の番号とは？
+        .add__submit
+        =f.submit "次へ進む", class:"add__submit__btn"
+= render "mercari_bottom"

--- a/app/views/signup/reg.html.haml
+++ b/app/views/signup/reg.html.haml
@@ -4,7 +4,7 @@
     .signup__wrapper__head 会員情報入力
     .signup__wrapper__registration
       .signup__wrapper__registration__form
-      = form_for @user, url: root_path, method: :get, html: {class: 'first-main__box'} do |f|
+      = form_for @user, url: tell_signup_index_path, method: :get, html: {class: 'first-main__box'} do |f|
         .signup__wrapper__registration__form__box
           ニックネーム
           %span.form-require 必須

--- a/app/views/signup/reg.html.haml
+++ b/app/views/signup/reg.html.haml
@@ -9,7 +9,7 @@
           ニックネーム
           %span.form-require 必須
           .signup-content__input-location
-          = f.text_field :email, placeholder: ' 例) メルカリ太郎', class:"input__default"
+          = f.text_field :nickname, placeholder: ' 例) メルカリ太郎', class:"input__default"
         .signup__wrapper__registration__form__box
           メールアドレス
           %span.form-require 必須   
@@ -18,7 +18,7 @@
           .signup__wrapper__registration__form__pass__title
             パスワード
             %span.form-require 必須
-          = f.password_field :email, placeholder: ' 7文字以上の半角英数', class:"input__default"
+          = f.password_field :encrypted_password, placeholder: ' 7文字以上の半角英数', class:"input__default"
           .signup__wrapper__registration__form__pass__content
             ※ 英字と数字の両方を含めて設定してください
           .signup__wrapper__registration__form__pass__check
@@ -34,25 +34,28 @@
           お名前(全角)
           %span.form-require 必須
           .signup-content__input-location
-          = f.password_field :email, placeholder: ' 例) 山田', class:"input__half"
-          = f.password_field :email, placeholder: ' 例) 彩', class:"input__half"
+          = f.text_field :f_name_kanji, placeholder: ' 例) 山田', class:"input__half"
+          = f.text_field :l_name_kanji, placeholder: ' 例) 彩', class:"input__half"
         .signup__wrapper__registration__form__box
           お名前カナ(全角)
           %span.form-require 必須
           .signup-content__input-location
-          = f.password_field :email, placeholder: ' 例) ヤマダ', class:"input__half"
-          = f.password_field :email, placeholder: ' 例) アヤ', class:"input__half"
+          = f.text_field :f_name_kana, placeholder: ' 例) ヤマダ', class:"input__half"
+          = f.text_field :l_name_kana, placeholder: ' 例) アヤ', class:"input__half"
         .signup__wrapper__registration__form__box
           生年月日
           %span.form-require 必須
           .signup-content__input-location
           -# != sprintf(f.date_select(:birthday, prefix:'birthday',with_css_classes:'input__half', prompt:"--",use_month_numbers:true, start_year:Time.now.year, end_year:1900, date_separator:'%s'),'年','月')+'日'
-          -# ↑ データベースに生年月日が作れていないためコメントアウト
-          %select.input__day
+         
+          .input__day
+          = f.select :birth_year, [["2019", "2019"], ["2018", "2018"],["2017", "2017"],["2016", "2016"],["2015", "2015"],["2014", "2014"],["2013", "2013"],["2012", "2012"],["2011", "2011"],["2010", "2010"],["2009", "2009"],["2008", "2008"],["2007", "2007"],["2006", "2006"],["2005", "2005"],["2004", "2004"],["2003", "2003"],["2002", "2002"],["2001", "2001"],["2000", "2000"],["1999", "1999"],["1998", "1998"],["1997", "1997"],["1996", "1996"],["1995", "1995"],["1994", "1994"],["1993", "1993"],["1992", "1992"],["1991", "1991"],["1990", "1990"],["1989", "1989"],["1988", "1988"],["1987", "1987"],["1986", "1986"],["1985", "1985"],["1984", "1984"],["1983", "1983"],["1982", "1982"],["1981", "1981"],["1980", "1980"]], class:"input__number"
           年
-          %select.input__day
+          .input__day
+          = f.select :birth_month, [["01", "01"], ["02", "02"],["03", "03"],["04", "04"],["05", "05"],["06", "06"],["07", "07"],["08", "08"],["09", "09"],["10", "10"],["11", "11"],["12", "12"]], class:"input__number" 
           月
-          %select.input__day
+          .input__day
+          = f.select :birth_day, [["01", "01"], ["02", "02"],["03", "03"],["04", "04"],["05", "05"],["06", "06"],["07", "07"],["08", "08"],["09", "09"],["10", "10"],["11", "11"],["12", "12"],["13", "13"],["14", "14"],["15", "15"],["16", "16"],["17", "17"],["18", "18"],["19", "19"],["20", "20"],["21", "21"],["22", "22"],["23", "23"],["24", "24"],["25", "25"],["26", "26"],["27", "27"],["28", "28"],["29", "29"],["30", "30"],["31", "31"]], class:"input__number"
           日
           .signup__wrapper__registration__form__box__comment
             ※ 本人情報は正しく入力してください。会員登録後、<br>

--- a/app/views/signup/tell.html.haml
+++ b/app/views/signup/tell.html.haml
@@ -5,9 +5,8 @@
     .signup__wrapper__tell
       .signup__wrapper__tell__form
         = form_for @user, url: add_signup_index_path, method: :get, html: {class: 'first-main__box'} do |f|
-          -# 送信した先の画面はどうするか
           .signup__wrapper__tell__form__title 携帯電話の番号
-          = f.text_field :email, placeholder: ' 携帯電話の番号を入力', class:"input__default"
+          = f.text_field :phone_number, placeholder: ' 携帯電話の番号を入力', class:"input__default"
           .signup__wrapper__tell__form__message
             本人確認のため、携帯電話のSMS(ショートメッセージ<br>
             サービス)を利用して認証を行います。

--- a/app/views/signup/tell.html.haml
+++ b/app/views/signup/tell.html.haml
@@ -4,14 +4,15 @@
     .signup__wrapper__title 電話番号の確認
     .signup__wrapper__tell
       .signup__wrapper__tell__form
-        = form_for @user, url: root_path, method: :get, html: {class: 'first-main__box'} do |f|
+        = form_for @user, url: add_signup_index_path, method: :get, html: {class: 'first-main__box'} do |f|
+          -# 送信した先の画面はどうするか
           .signup__wrapper__tell__form__title 携帯電話の番号
           = f.text_field :email, placeholder: ' 携帯電話の番号を入力', class:"input__default"
           .signup__wrapper__tell__form__message
             本人確認のため、携帯電話のSMS(ショートメッセージ<br>
             サービス)を利用して認証を行います。
           .signup__wrapper__tell__form__submit
-          =f.submit "SMSを送信する", class:"submit__btn"
+          =f.submit "SMSを送信する", class:"submit__btn"       
           .signup__wrapper__tell__form__message
             ＊電話番号は本人確認や不正利用防止のために利用<br>
             します。他のユーザーに公開されることはありま<br>

--- a/app/views/signup/tell.html.haml
+++ b/app/views/signup/tell.html.haml
@@ -1,0 +1,24 @@
+= render "reg_header"
+.sigup
+  .signup__wrapper
+    .signup__wrapper__title 電話番号の確認
+    .signup__wrapper__tell
+      .signup__wrapper__tell__form
+        = form_for @user, url: root_path, method: :get, html: {class: 'first-main__box'} do |f|
+          .signup__wrapper__tell__form__title 携帯電話の番号
+          = f.text_field :email, placeholder: ' 携帯電話の番号を入力', class:"input__default"
+          .signup__wrapper__tell__form__message
+            本人確認のため、携帯電話のSMS(ショートメッセージ<br>
+            サービス)を利用して認証を行います。
+          .signup__wrapper__tell__form__submit
+          =f.submit "SMSを送信する", class:"submit__btn"
+          .signup__wrapper__tell__form__message
+            ＊電話番号は本人確認や不正利用防止のために利用<br>
+            します。他のユーザーに公開されることはありま<br>
+            せん。
+      .signup__wrapper__tell__reason
+        電話番号の確認が必要な理由
+        %i.fas.fa-chevron-right
+
+
+= render "mercari_bottom"

--- a/app/views/signup/top.html.haml
+++ b/app/views/signup/top.html.haml
@@ -1,9 +1,10 @@
+= render "mercari_top"
 .topmain
   .topmain__box
     .topmain__box__title 新規会員登録
     .topmain__box__form
       .topmain__box__form__btn
-        =link_to "/", class:"topmain__box__form__btn__mail" do
+        =link_to reg_signup_index_path, class:"topmain__box__form__btn__mail" do
           %i.far.fa-envelope.btn__mail{"aria-hidden": "true"} 
           %p1 メールアドレスで登録する
       .topmain__box__form__btn
@@ -14,3 +15,5 @@
         =link_to "/", class:"topmain__box__form__btn__google"  do
           %i.fab.fa-google.btn__google     
           %p3 Googleで登録する
+= render "mercari_bottom"
+-# リンク未実装ーー３箇所ーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーーー

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,15 +13,10 @@
 ActiveRecord::Schema.define(version: 2019_12_10_090957) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "user_id"
-    t.string "prefectures"
-    t.string "municipalities"
-    t.string "address"
-    t.string "building"
-    t.integer "phone_number"
+    t.integer "prefecture_id"
+    t.string "city"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["user_id"], name: "index_addresses_on_user_id"
   end
 
   create_table "credit_cards", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
@@ -55,6 +50,5 @@ ActiveRecord::Schema.define(version: 2019_12_10_090957) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
-  add_foreign_key "addresses", "users"
   add_foreign_key "credit_cards", "users"
 end


### PR DESCRIPTION
#what
ユーザー新規登録ログインページのマークアップ
電話認証ページ、住所入力、支払い方法、会員登録完了ページのマークアップ

#why
ユーザー登録ページのマークアップのレビューをお願いします。


前回キャプチャをつけて欲しいとコメントをいただいたので、添付します。
<img width="1264" alt="スクリーンショット 2019-12-12 14 17 17" src="https://user-images.githubusercontent.com/57390671/70684802-bc949300-1cea-11ea-8670-36885af82405.png">

<img width="1076" alt="スクリーンショット 2019-12-12 14 18 10" src="https://user-images.githubusercontent.com/57390671/70684807-c0c0b080-1cea-11ea-8743-1c3991d5dee0.png">

https://gyazo.com/3b8910ebd26b5b7a02cc318ea4ffbacd

https://gyazo.com/31f8831234986da3f8d37f7f3f3373ab