### PR TITLE
詳細ページ / 表示 / 追加

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -46,7 +46,7 @@ before_action :set_item, only:[:edit, :update]
   private
   
   def item_params 
-    params.require(:item).permit(:name, :explain, :state, :postage, :shipping_area, :shipping_date, :price, images_attributes: [:id, :image, :item_id], categories_attributes: [:id, :name, :item_id]).merge(user_id: current_user.id)
+    params.require(:item).permit(:name, :explain, :state, :postage, :shipping_area, :shipping_date, :price, :brand, :size, :delivery_way, images_attributes: [:id, :image, :item_id], categories_attributes: [:id, :name, :item_id]).merge(user_id: current_user.id)
   end
   
   def set_item

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -1,7 +1,7 @@
 class Item < ApplicationRecord
   has_many :images, dependent: :destroy
   has_many :categories, dependent: :destroy
-  belongs_to :user
+  belongs_to :user, dependent: :destroy
   accepts_nested_attributes_for :images
   accepts_nested_attributes_for :categories
   validates :name, {presence: true, length: {maximum: 40}}

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -96,6 +96,19 @@
           .exhibit-wrapper__sell-content__select-wrap
             =f.fields_for :categories do |i|
               =i.select :name, ["---","レディース","メンズ","ベビー・キッズ","インテリア・住まい・小物","本・音楽・ゲーム","おもちゃ・ホビー・グッズ","コスメ・香水・美容","家電・スマホ・カメラ","スポーツ・レジャー","ハンドメイド","チケット","自動車・オートバイ","その他"]
+          .exhibit-wrapper__sell-content__pulldown__name-category
+            %p 
+              ブランド
+              %span.form-require-gray  任意
+              -# 任意は灰色に
+          .exhibit-wrapper__sell-content__select-wrap
+            =f.text_field :brand, id: "brand", placeholder: "例) adidas"
+          .exhibit-wrapper__sell-content__pulldown__name-category
+            %p 
+              商品のサイズ
+              %span.form-require  必須
+          .exhibit-wrapper__sell-content__select-wrap
+            =f.select :size, ["---","XSS以下","XS(SS)","S","M","L","XL(LL)","2XL(3L)","3XL(4L)"]
           .exhibit-wrapper__sell-content__pulldown__name-state
             %p 
               商品の状態 
@@ -112,6 +125,12 @@
               %span.form-require 必須
             .exhibit-wrapper__sell-content__select-wrap
               =f.select :postage, ["---","送料込み(出品者負担)","着払い(購入者負担)"]
+          .exhibit-wrapper__sell-content__pulldown__name-delivery
+            %p 
+              配送の方法 
+              %span.form-require 必須
+            .exhibit-wrapper__sell-content__select-wrap
+              =f.select :delivery_way, ["---","未定","らくらくメルカリ便","ゆうメール","ゆうパケット"]    
           .exhibit-wrapper__sell-content__pulldown__name-delivery
             %p 
               発送元の地域 

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -14,7 +14,7 @@
             %td.item__content__table__title 出品者
             %td.item__content__table__content 
               .item__content__table__content__name 
-              =@item.user_id
+                =@item.user.nickname
               .item__content__table__content__box
                 .item__content__table__content__box__smile
                   %i.fas.fa-laugh-beam
@@ -32,9 +32,11 @@
           %tr 
             %td.item__content__table__titles ブランド
             %td.item__content__table__contents 
+              =@item.brand
           %tr 
             %td.item__content__table__titles 商品のサイズ
             %td.item__content__table__contents
+              =@item.size
           %tr 
             %td.item__content__table__titles 商品の状態
             %td.item__content__table__contents 
@@ -46,6 +48,7 @@
           %tr 
             %td.item__content__table__titles 配送の方法
             %td.item__content__table__contents 
+              =@item.delivery_way
           %tr 
             %td.item__content__table__titles 配送元地域
             %td.item__content__table__contents

--- a/db/migrate/20191210072208_create_items.rb
+++ b/db/migrate/20191210072208_create_items.rb
@@ -13,6 +13,9 @@ class CreateItems < ActiveRecord::Migration[5.2]
       t.string :state, null: false 
       t.references :buyer
       t.references :user, foreign_key: true
+      t.string :brand
+      t.string :size, null: false
+      t.string :delivery_way, null: false 
       t.timestamps
     end
   end


### PR DESCRIPTION
# What 
出品者・ブランド・サイズ・配送の方法を出品ページで登録でき、詳細ページに表示されるようにした。

# Why
ユーザーが、それらの商品情報を登録して確認する事が出来るようにするため。