### PR TITLE
モーダル　出品するボタン

### DIFF
--- a/app/assets/stylesheets/_new.scss
+++ b/app/assets/stylesheets/_new.scss
@@ -45,6 +45,7 @@ body {
           a {
             color: #fff;
             text-decoration: none;
+            padding: 13px 217px;
           }
         }
         .show {

--- a/app/views/items/new.html.haml
+++ b/app/views/items/new.html.haml
@@ -8,7 +8,7 @@
       .modal-body
         %p あなたが出品した商品は「トップページ」からいつでも見ることができます。
         .btn-red
-          =link_to "続けて出品する",new_item_path, id: "continue"
+          =link_to "続けて出品する",new_item_path
         .show
           =link_to "トップページに戻る", root_path, id: "show"
   .exhibit-wrapper


### PR DESCRIPTION
# What
「出品する」ボタンを押した後のモーダルに表示される「続けて出品する」ボタンのどこを押しても反応するようにする。

# Why
ユーザービリティを高めるため