### PR TITLE
条件分岐　出品ボタンを押した後　

### DIFF
--- a/app/views/layouts/_circle.html.haml
+++ b/app/views/layouts/_circle.html.haml
@@ -1,3 +1,8 @@
-=link_to  new_item_path, class:"footer__lower__circle" do
-  %p 出品
-  %i.fas.fa-camera.camera
+-if user_signed_in?
+  =link_to  new_item_path, class:"footer__lower__circle" do
+    %p 出品
+    %i.fas.fa-camera.camera
+-else 
+  =link_to  new_user_session_path, class:"footer__lower__circle" do
+    %p 出品
+    %i.fas.fa-camera.camera


### PR DESCRIPTION
# What
ユーザーがログインしている時は、出品ページ
していない時はログインページへ飛ぶようにしました。
　
ログインページに新規登録画面もあるので、アカウントを持っていない人がアクセスしても大丈夫です。

# Why
ユーザーがログインしていない時に、出品ページを押してもエラーが出ないようにようにするため。